### PR TITLE
Updated to support the new token based auth

### DIFF
--- a/chargeHQ.sh
+++ b/chargeHQ.sh
@@ -7,12 +7,20 @@ endpoint="https://api.chargehq.net/api/public/push-solar-data"
 apiKey="<apiKey>"
 local_envoy_ip="envoy.local"
 interval=60
+# get token from: https://enlighten.enphaseenergy.com/entrez-auth-token?serial_num=<envoy-serial-number>  
+sixMonthToken="<token>"
+
 
 while true; do
 
 sleep $interval &
 
-envoycontent=$( curl -m 30 -s -X GET -H "Accept: application/json" "http://$local_envoy_ip/production.json" )
+# write the sessionId cookie to local file and ignore self signed certificate
+session=$( curl -k -m 30 -s -S -c "cookies.jar" -X GET -H "Accept: application/json" -H "Authorization: Bearer $sixMonthToken" "https://$local_envoy_ip/auth/check_jwt" )
+
+# make request with cookie file containing sessionId 
+envoycontent=$( curl -k -m 30 -s -S -b "cookies.jar" -X GET -H "Accept: application/json" "https://$local_envoy_ip/production.json" )
+
 production_kw=$( jq -r '.production[1].wNow/1000' <<< "${envoycontent}" | sed -E 's/\.([0-9]{3})[0-9]*/.\1/g' | sed 's/^-.*/0/' )
 consumption_kw=$( jq -r '.consumption[0].wNow/1000' <<< "${envoycontent}" | sed -E 's/\.([0-9]{3})[0-9]*/.\1/g' )
 


### PR DESCRIPTION
My Enphase system is pretty new and seems to have the new token based auth that there's various complaints about. 

So far the only official local documentation I can find is here: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication plus gleaned some things from forum posts. 

However the APIs mentioned in the PDF are only updated every 5 minutes and .../livedata/status returns a 401 so don't know what's going on there.  But looks like the envoy gateway's own local page still uses production.json endpoint and it has a checkjwt endpoint to set a sessionId cookie. 

Since its meant to last either 6 or 12 months, I'm just going to set a calendar reminder to update it every 6 months. Only just got this working an hour ago so will monitor it over the coming days.